### PR TITLE
Update DLP report with filter limitation

### DIFF
--- a/microsoft-365/compliance/view-the-dlp-reports.md
+++ b/microsoft-365/compliance/view-the-dlp-reports.md
@@ -95,5 +95,9 @@ However, DLP reports need pull data from across Office 365, including Exchange O
       - [Get-DlpDetectionsReport](https://go.microsoft.com/fwlink/?LinkID=799774&amp;clcid=0x409)
     
       - [Get-DlpDetailReport](https://go.microsoft.com/fwlink/?LinkID=799775&amp;clcid=0x409)
+      
+## Limitations of DLP reports
+
+If your organization has a large amount of DLP policies you may have to query by group of policies or filter by DLP policy service.  As by default report will return all policies unless filter or query is applied.  This is due to the content URL length being exceeded as each policy will add to the length of URL for DLP report and may result in a 500 server error.  Improvements are planned in the future where these limits will not apply. 
     
 

--- a/microsoft-365/compliance/view-the-dlp-reports.md
+++ b/microsoft-365/compliance/view-the-dlp-reports.md
@@ -98,6 +98,6 @@ However, DLP reports need pull data from across Office 365, including Exchange O
       
 ## Limitations of DLP reports
 
-If your organization has a large amount of DLP policies you may have to query by group of policies or filter by DLP policy service.  As by default report will return all policies unless filter or query is applied.  This is due to the content URL length being exceeded as each policy will add to the length of URL for DLP report and may result in a 500 server error.  Improvements are planned in the future where these limits will not apply. 
+If your organization has a large amount of DLP policies you may have to query by group of policies or filter by DLP policy service, as by default report will return all policies unless filter or query is applied. This is due to the content URL length being exceeded as each policy will add to the length of URL for DLP report and may result in a 500 server error. Improvements are planned in the future where these limits will not apply.
     
 


### PR DESCRIPTION
We need to update the documentation around scenario where a customer may have such a large amount of DLP policies that they may encounter 500 error upon attempting to get DLP report in SCC UI.  This is due to all policies being returned by default for report and when customer has a large amount of DLP policies being returned the content URL length is exceeded, causing the 500 error.  Customer must use a filter in this case in which they can filter DLP policies by service or by querying a group of policies.  We may want to add a screenshot showing example of using filter by service or query by group of policies.